### PR TITLE
Relocates _start_with? method to array.rb

### DIFF
--- a/lib/foobara/util/array.rb
+++ b/lib/foobara/util/array.rb
@@ -36,5 +36,15 @@ module Foobara
         )
       end
     end
+
+    def _start_with?(large_array, small_array)
+      return false unless large_array.size > small_array.size
+
+      small_array.each.with_index do |item, index|
+        return false unless large_array[index] == item
+      end
+
+      true
+    end
   end
 end


### PR DESCRIPTION
Fixes issue #15 in the main foobara repository